### PR TITLE
Patch manifest URL to match the URL used by Obsidian

### DIFF
--- a/src/util/GitHub.ts
+++ b/src/util/GitHub.ts
@@ -87,7 +87,7 @@ export async function fetchReleases(repository: string): Promise<Partial<Release
 				prerelease: value.prerelease,
 				manifest_url: value.assets.find( asset => {
 					asset.name === "manifest.json"
-				}).browser_download_url
+				})?.browser_download_url
 			};
 		});
 		return releases;

--- a/src/util/GitHub.ts
+++ b/src/util/GitHub.ts
@@ -85,6 +85,9 @@ export async function fetchReleases(repository: string): Promise<Partial<Release
 			return {
 				tag_name: value.tag_name,
 				prerelease: value.prerelease,
+				manifest_url: value.assets.find( asset => {
+					asset.name === "manifest.json"
+				}).browser_download_url
 			};
 		});
 		return releases;
@@ -101,8 +104,8 @@ export async function fetchReleases(repository: string): Promise<Partial<Release
  * @param tag_name The name of the tag associated with a release. Required if a specific manifest version is needed.
  * @returns The plugin manifest object
  */
-export async function fetchManifest(repository: string, tag_name?: string): Promise<PluginManifest | undefined> {
-	const URL = `https://raw.githubusercontent.com/${repository}/${tag_name ? tag_name : 'HEAD'}/manifest.json`;
+export async function fetchManifest(repository: string, tag_name?: string, manifest_url?: string): Promise<PluginManifest | undefined> {
+	const URL = manifest_url ? manifest_url : `https://raw.githubusercontent.com/${repository}/${tag_name ? tag_name : 'HEAD'}/manifest.json`;
 	try {
 		if (!repositoryRegEx.test(repository)) {
 			throw Error('Repository string do not match the pattern!');

--- a/src/util/GitHub.ts
+++ b/src/util/GitHub.ts
@@ -85,9 +85,9 @@ export async function fetchReleases(repository: string): Promise<Partial<Release
 			return {
 				tag_name: value.tag_name,
 				prerelease: value.prerelease,
-				manifest_url: value.assets.find( asset => {
-					asset.name === "manifest.json"
-				})?.browser_download_url
+				manifest_url: value.assets.find(asset => {
+					asset.name === 'manifest.json';
+				})?.browser_download_url,
 			};
 		});
 		return releases;


### PR DESCRIPTION
add a patch to pull the manifest download URL from the Releases REST API

<!-- In the title above, provide a meaningful summary with [FIX] for bug fix and [FEAT] for new feature --->

## Describe your changes
- changes fetchReleases to return a manifest_url on all releases
- changes fetchManifest to accept a predetermined manifest url (typically fed by the above change)

## Related Issues
Fixes #12 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~ N/A
- [x] My code fixes the feature discussed in [Related Issues](#related-issues)
