### PR TITLE
[FIX] Manifest URL

### DIFF
--- a/src/modals/PluginDataModal.ts
+++ b/src/modals/PluginDataModal.ts
@@ -70,11 +70,11 @@ export class PluginDataModal extends Modal {
 					}
 					// Check a manifest could be fetched
 					const manifest =
-						await fetchManifest(undefined,undefined,releases[0].manifest_url) ||
+						await fetchManifest(undefined,undefined,releases[0]) ||
 						await fetchManifest(repo, releases[0].tag_name) ||
 						await fetchManifest(repo);
 					if (!manifest) {
-						new Notice('Github repository could not be found!');
+						new Notice('Plugin manifest could not be found in releases, tag ref, or default branch!');
 						return;
 					}
 					// Combine data

--- a/src/modals/PluginDataModal.ts
+++ b/src/modals/PluginDataModal.ts
@@ -62,16 +62,19 @@ export class PluginDataModal extends Modal {
 						new Notice('Github <username>/<repository> do not match the pattern!');
 						return;
 					}
-					// Check a manifest could be fetched
-					const manifest = await fetchManifest(repo);
-					if (!manifest) {
-						new Notice('Github repository could not be found!');
-						return;
-					}
 					// check there are releases for the repo
 					const releases = await fetchReleases(repo);
 					if (!releases || releases.length <= 0) {
 						new Notice('No releases found for this plugin. May it do not have any.');
+						return;
+					}
+					// Check a manifest could be fetched
+					const manifest =
+						await fetchManifest(undefined,undefined,releases[0].manifest_url) ||
+						await fetchManifest(repo, releases[0].tag_name) ||
+						await fetchManifest(repo);
+					if (!manifest) {
+						new Notice('Github repository could not be found!');
 						return;
 					}
 					// Combine data

--- a/src/modals/PluginTroubleshootingModal.ts
+++ b/src/modals/PluginTroubleshootingModal.ts
@@ -41,7 +41,14 @@ export class PluginTroubleshootingModal extends Modal {
 				.setPlaceholder('Username')
 				.setValue(username)
 				.onChange(value => {
+					if (value.contains('/')) {
+						const repoSections = value.split('/');
+						username = repoSections[0];
+						repository = repoSections[1];
+					}
+					else {
 					username = value;
+					}
 					updateRepo();
 				}));
 
@@ -52,7 +59,14 @@ export class PluginTroubleshootingModal extends Modal {
 				.setPlaceholder('Repository')
 				.setValue(repository)
 				.onChange(value => {
+					if (value.contains('/')) {
+						const repoSections = value.split('/');
+						username = repoSections[0];
+						repository = repoSections[1];
+					}
+					else {
 					repository = value;
+					}
 					updateRepo();
 				}));
 

--- a/src/modals/PluginTroubleshootingModal.ts
+++ b/src/modals/PluginTroubleshootingModal.ts
@@ -23,7 +23,7 @@ export class PluginTroubleshootingModal extends Modal {
 		let repository = this.pluginInfo.repo.split('/').at(1) || '';
 		let manifest: PluginManifest | undefined;
 		let hasManifest = false;
-		let releases: Partial<Release>[] | undefined;
+		// let releases: Partial<Release>[] | undefined;
 		let hasReleases = false;
 
 		// Debonce text input
@@ -68,7 +68,7 @@ export class PluginTroubleshootingModal extends Modal {
 					this.update();
 				}));
 				
-		releases = await fetchReleases(this.pluginInfo.repo);
+		const releases = await fetchReleases(this.pluginInfo.repo);
 		hasReleases = releases !== undefined && (releases.length > 0);
 		new Setting(contentEl)
 			.setName('Test releases')

--- a/src/modals/PluginTroubleshootingModal.ts
+++ b/src/modals/PluginTroubleshootingModal.ts
@@ -69,7 +69,7 @@ export class PluginTroubleshootingModal extends Modal {
 				}));
 
 		if (repositoryRegEx.test(this.pluginInfo.repo)) {
-			manifest = await fetchManifest(this.pluginInfo.repo);
+			manifest = await fetchManifest(this.pluginInfo.repo); // leaving this one alone as it seems to serve a different purpose - Blue Falcon
 			hasManifest = manifest !== undefined;
 			new Setting(contentEl)
 				.setName('Test connection')

--- a/src/modals/PluginTroubleshootingModal.ts
+++ b/src/modals/PluginTroubleshootingModal.ts
@@ -67,32 +67,33 @@ export class PluginTroubleshootingModal extends Modal {
 				.onClick(() => {
 					this.update();
 				}));
+				
+		releases = await fetchReleases(this.pluginInfo.repo);
+		hasReleases = releases !== undefined && (releases.length > 0);
+		new Setting(contentEl)
+			.setName('Test releases')
+			.setDesc(hasReleases ? '' : 'Could not find releases on GitHub. May this plugin did not have any.')
+			.addExtraButton(button => button
+				.setIcon(hasReleases ? ICON_ACCEPT : ICON_DENY)
+				.setTooltip(hasReleases ? '' : 'Try again?')
+				.setDisabled(hasReleases)
+				.onClick(() => {
+					this.update();
+				}));
 
-		if (repositoryRegEx.test(this.pluginInfo.repo)) {
-			manifest = await fetchManifest(this.pluginInfo.repo); // leaving this one alone as it seems to serve a different purpose - Blue Falcon
+		if (repositoryRegEx.test(this.pluginInfo.repo) || hasReleases) {
+			const last_release = releases ? releases[0] : undefined;
+			manifest =
+				await fetchManifest(undefined,undefined,last_release) ||
+				await fetchManifest(this.pluginInfo.repo);
 			hasManifest = manifest !== undefined;
 			new Setting(contentEl)
-				.setName('Test connection')
-				.setDesc(hasManifest ? '' : 'Repo could not be found on GitHub. Is everything typed correctly?')
+				.setName('Test manifest')
+				.setDesc(hasManifest ? '' : 'Manifest could not be found on GitHub. Is everything including the repo typed correctly?')
 				.addExtraButton(button => button
 					.setIcon(hasManifest ? ICON_ACCEPT : ICON_DENY)
 					.setTooltip(hasManifest ? '' : 'Try again?')
 					.setDisabled(hasManifest)
-					.onClick(() => {
-						this.update();
-					}));
-		}
-
-		if (hasManifest) {
-			releases = await fetchReleases(this.pluginInfo.repo);
-			hasReleases = releases !== undefined && (releases.length > 0);
-			new Setting(contentEl)
-				.setName('Test releases')
-				.setDesc(hasReleases ? '' : 'Could not find releases on GitHub. May this plugin did not have any.')
-				.addExtraButton(button => button
-					.setIcon(hasReleases ? ICON_ACCEPT : ICON_DENY)
-					.setTooltip(hasReleases ? '' : 'Try again?')
-					.setDisabled(hasReleases)
 					.onClick(() => {
 						this.update();
 					}));

--- a/src/modals/PluginTroubleshootingModal.ts
+++ b/src/modals/PluginTroubleshootingModal.ts
@@ -2,7 +2,7 @@ import { Modal, PluginManifest, Setting, debounce } from 'obsidian';
 import { ICON_ACCEPT, ICON_DENY } from 'src/constants';
 import VarePlugin from 'src/main';
 import { PluginInfo } from 'src/settings/SettingsInterface';
-import { /* Release, */ fetchManifest, fetchReleases, repositoryRegEx } from 'src/util/GitHub';
+import { fetchManifest, fetchReleases, repositoryRegEx } from 'src/util/GitHub';
 
 export class PluginTroubleshootingModal extends Modal {
 	plugin: VarePlugin;
@@ -23,7 +23,6 @@ export class PluginTroubleshootingModal extends Modal {
 		let repository = this.pluginInfo.repo.split('/').at(1) || '';
 		let manifest: PluginManifest | undefined;
 		let hasManifest = false;
-		// let releases: Partial<Release>[] | undefined;
 		let hasReleases = false;
 
 		// Debonce text input

--- a/src/modals/PluginTroubleshootingModal.ts
+++ b/src/modals/PluginTroubleshootingModal.ts
@@ -2,7 +2,7 @@ import { Modal, PluginManifest, Setting, debounce } from 'obsidian';
 import { ICON_ACCEPT, ICON_DENY } from 'src/constants';
 import VarePlugin from 'src/main';
 import { PluginInfo } from 'src/settings/SettingsInterface';
-import { fetchManifest, fetchReleases, repositoryRegEx } from 'src/util/GitHub';
+import { Release, fetchManifest, fetchReleases, repositoryRegEx } from 'src/util/GitHub';
 
 export class PluginTroubleshootingModal extends Modal {
 	plugin: VarePlugin;
@@ -81,7 +81,7 @@ export class PluginTroubleshootingModal extends Modal {
 					this.update();
 				}));
 		
-		let releases = undefined;
+		let releases: Partial<Release>[] | undefined = undefined;
 		if (repositoryRegEx.test(this.pluginInfo.repo)) {
 			releases = await fetchReleases(this.pluginInfo.repo);
 			hasReleases = releases !== undefined && (releases.length > 0);

--- a/src/modals/PluginTroubleshootingModal.ts
+++ b/src/modals/PluginTroubleshootingModal.ts
@@ -47,7 +47,7 @@ export class PluginTroubleshootingModal extends Modal {
 						repository = repoSections[1];
 					}
 					else {
-					username = value;
+						username = value;
 					}
 					updateRepo();
 				}));
@@ -65,7 +65,7 @@ export class PluginTroubleshootingModal extends Modal {
 						repository = repoSections[1];
 					}
 					else {
-					repository = value;
+						repository = value;
 					}
 					updateRepo();
 				}));
@@ -80,24 +80,27 @@ export class PluginTroubleshootingModal extends Modal {
 				.onClick(() => {
 					this.update();
 				}));
-				
-		const releases = await fetchReleases(this.pluginInfo.repo);
-		hasReleases = releases !== undefined && (releases.length > 0);
-		new Setting(contentEl)
-			.setName('Test releases')
-			.setDesc(hasReleases ? '' : 'Could not find releases on GitHub. May this plugin did not have any.')
-			.addExtraButton(button => button
-				.setIcon(hasReleases ? ICON_ACCEPT : ICON_DENY)
-				.setTooltip(hasReleases ? '' : 'Try again?')
-				.setDisabled(hasReleases)
-				.onClick(() => {
-					this.update();
-				}));
+		
+		let releases = undefined;
+		if (repositoryRegEx.test(this.pluginInfo.repo)) {
+			releases = await fetchReleases(this.pluginInfo.repo);
+			hasReleases = releases !== undefined && (releases.length > 0);
+			new Setting(contentEl)
+				.setName('Test releases')
+				.setDesc(hasReleases ? '' : 'Could not find releases on GitHub. May this plugin did not have any.')
+				.addExtraButton(button => button
+					.setIcon(hasReleases ? ICON_ACCEPT : ICON_DENY)
+					.setTooltip(hasReleases ? '' : 'Try again?')
+					.setDisabled(hasReleases)
+					.onClick(() => {
+						this.update();
+					}));
+		}
 
-		if (repositoryRegEx.test(this.pluginInfo.repo) || hasReleases) {
+		if (repositoryRegEx.test(this.pluginInfo.repo) && hasReleases) {
 			const last_release = releases ? releases[0] : undefined;
 			manifest =
-				await fetchManifest(undefined,undefined,last_release) ||
+				await fetchManifest(undefined, undefined, last_release) ||
 				await fetchManifest(this.pluginInfo.repo);
 			hasManifest = manifest !== undefined;
 			new Setting(contentEl)

--- a/src/modals/PluginTroubleshootingModal.ts
+++ b/src/modals/PluginTroubleshootingModal.ts
@@ -2,7 +2,7 @@ import { Modal, PluginManifest, Setting, debounce } from 'obsidian';
 import { ICON_ACCEPT, ICON_DENY } from 'src/constants';
 import VarePlugin from 'src/main';
 import { PluginInfo } from 'src/settings/SettingsInterface';
-import { Release, fetchManifest, fetchReleases, repositoryRegEx } from 'src/util/GitHub';
+import { /* Release, */ fetchManifest, fetchReleases, repositoryRegEx } from 'src/util/GitHub';
 
 export class PluginTroubleshootingModal extends Modal {
 	plugin: VarePlugin;

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -186,7 +186,11 @@ export class VareSettingTab extends PluginSettingTab {
 							.onClick(async () => {
 								try {
 									// Fetch the manifest from GitHub
-									const manifest = await fetchManifest(plugin.repo, plugin.targetVersion);
+									const manifest_url = plugin.releases.find(release => release.tag_name === plugin.targetVersion)?.manifest_url;
+									const manifest =
+										await fetchManifest(undefined,undefined,manifest_url) ||
+										await fetchManifest(plugin.repo, plugin.targetVersion) ||
+										await fetchManifest(plugin.repo);
 									if (!manifest) {
 										throw Error('No manifest found for this plugin!');
 									}

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -186,9 +186,9 @@ export class VareSettingTab extends PluginSettingTab {
 							.onClick(async () => {
 								try {
 									// Fetch the manifest from GitHub
-									const manifest_url = plugin.releases.find(release => release.tag_name === plugin.targetVersion)?.manifest_url;
+									const release = plugin.releases.find(release => release.tag_name === plugin.targetVersion);
 									const manifest =
-										await fetchManifest(undefined,undefined,manifest_url) ||
+										await fetchManifest(undefined,undefined,release) ||
 										await fetchManifest(plugin.repo, plugin.targetVersion) ||
 										await fetchManifest(plugin.repo);
 									if (!manifest) {

--- a/src/util/GitHub.ts
+++ b/src/util/GitHub.ts
@@ -16,7 +16,6 @@ export interface CommunityPlugin {
 
 export type Release = {
 	url: string;
-	manifest_url: string;
 	html_url: string;
 	assets_url: string;
 	upload_url: string;
@@ -86,7 +85,6 @@ export async function fetchReleases(repository: string): Promise<Partial<Release
 			return {
 				tag_name: value.tag_name,
 				prerelease: value.prerelease,
-				manifest_url: value.assets.find((asset: Asset) => asset.name === 'manifest.json')?.browser_download_url,
 			};
 		});
 		return releases;
@@ -101,11 +99,12 @@ export async function fetchReleases(repository: string): Promise<Partial<Release
  * Fetch the manifest for a plugin
  * @param repository The <user>/<repo> of the plugin
  * @param tag_name The name of the tag associated with a release. Required if a specific manifest version is needed.
- * @param url The url to the manifest file. Optional. If not provided, the default url will be used.
+ * @param release The release object of the plugin. Used to replicate Obsidian's behavior of fetching the manifest for the plugin.
  * @returns The plugin manifest object
  */
-export async function fetchManifest(repository?: string, tag_name?: string, url?:string): Promise<PluginManifest | undefined> {
-	url = url ? url : `https://raw.githubusercontent.com/${repository}/${tag_name ? tag_name : 'HEAD'}/manifest.json`;
+export async function fetchManifest(repository?: string, tag_name?: string, release?: Partial<Release>): Promise<PluginManifest | undefined> {
+	const download_url: string | undefined = release?.assets?.find((asset: Asset) => asset.name === 'manifest.json')?.browser_download_url;
+	const url: string = download_url ? download_url : `https://raw.githubusercontent.com/${repository}/${tag_name ? tag_name : 'HEAD'}/manifest.json`;
 	try {
 		if (repository && !repositoryRegEx.test(repository)) {
 			throw Error('Repository string do not match the pattern!');

--- a/src/util/GitHub.ts
+++ b/src/util/GitHub.ts
@@ -86,9 +86,7 @@ export async function fetchReleases(repository: string): Promise<Partial<Release
 			return {
 				tag_name: value.tag_name,
 				prerelease: value.prerelease,
-				manifest_url: value.assets.find((asset: Asset) => {
-					asset.name === 'manifest.json';
-				})?.browser_download_url,
+				manifest_url: value.assets.find((asset: Asset) => asset.name === 'manifest.json')?.browser_download_url,
 			};
 		});
 		return releases;

--- a/src/util/GitHub.ts
+++ b/src/util/GitHub.ts
@@ -85,6 +85,7 @@ export async function fetchReleases(repository: string): Promise<Partial<Release
 			return {
 				tag_name: value.tag_name,
 				prerelease: value.prerelease,
+				assets: value.assets,
 			};
 		});
 		return releases;


### PR DESCRIPTION
Corrects the manifest URL to use the same URL that Obsidian does, which is the one on the Release Asset

## Describe your changes
- changes fetchReleases() to populate releases with a manifest_url
- changes fetchManifest() to accept a manifest_url

## Related Issues
Fixes #12 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~ N/A
- [x] My code fixes the feature discussed in [Related Issues](#related-issues)
